### PR TITLE
Does not contain text matcher

### DIFF
--- a/src/main/java/com/codeborne/xlstest/XLS.java
+++ b/src/main/java/com/codeborne/xlstest/XLS.java
@@ -59,7 +59,7 @@ public class XLS {
     return new ContainsRow(cellTexts);
   }
 
-  public static Matcher<XLS> doesNotContainsText(String text) {
+  public static Matcher<XLS> doesNotContainText(String text) {
     return new DoesNotContainText(text);
   }
 }

--- a/src/main/java/com/codeborne/xlstest/XLS.java
+++ b/src/main/java/com/codeborne/xlstest/XLS.java
@@ -2,6 +2,7 @@ package com.codeborne.xlstest;
 
 import com.codeborne.xlstest.matchers.ContainsRow;
 import com.codeborne.xlstest.matchers.ContainsText;
+import com.codeborne.xlstest.matchers.DoesNotContainText;
 import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.ss.usermodel.WorkbookFactory;
 import org.hamcrest.Matcher;
@@ -41,7 +42,7 @@ public class XLS {
   public XLS(URI uri) throws IOException {
     this(uri.toURL());
   }
-  
+
   public XLS(byte[] content) {
     this("", content);
   }
@@ -49,12 +50,16 @@ public class XLS {
   public XLS(InputStream inputStream) throws IOException {
     this(readBytes(inputStream));
   }
-  
+
   public static Matcher<XLS> containsText(String text) {
     return new ContainsText(text);
   }
 
   public static Matcher<XLS> containsRow(String... cellTexts) {
     return new ContainsRow(cellTexts);
+  }
+
+  public static Matcher<XLS> doesNotContainsText(String text) {
+    return new DoesNotContainText(text);
   }
 }

--- a/src/main/java/com/codeborne/xlstest/matchers/DoesNotContainText.java
+++ b/src/main/java/com/codeborne/xlstest/matchers/DoesNotContainText.java
@@ -1,0 +1,24 @@
+package com.codeborne.xlstest.matchers;
+
+import com.codeborne.xlstest.XLS;
+import org.hamcrest.Description;
+
+public class DoesNotContainText extends XLSMatcher {
+
+  private final String substring;
+
+  public DoesNotContainText(String substring) {
+    this.substring = reduceSpaces(substring);
+  }
+
+  @Override
+  protected boolean matchesSafely(XLS item) {
+    boolean contains = new ContainsText(substring).matchesSafely(item);
+    return !contains;
+  }
+
+  @Override
+  public void describeTo(Description description) {
+    description.appendText("a XLS not containing text ").appendValue(reduceSpaces(substring));
+  }
+}

--- a/src/test/java/com/codeborne/xlstest/matchers/ContainsTextTest.java
+++ b/src/test/java/com/codeborne/xlstest/matchers/ContainsTextTest.java
@@ -8,7 +8,7 @@ import java.io.IOException;
 import java.util.Objects;
 
 import static com.codeborne.xlstest.XLS.containsText;
-import static com.codeborne.xlstest.XLS.doesNotContainsText;
+import static com.codeborne.xlstest.XLS.doesNotContainText;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.fail;
@@ -55,14 +55,14 @@ public class ContainsTextTest {
   @Test
   public void canAssertXlsDoesNotContainText() throws IOException {
     XLS xls = new XLS(Objects.requireNonNull(getClass().getClassLoader().getResource("statement.xls")));
-    assertThat(xls, doesNotContainsText("null"));
+    assertThat(xls, doesNotContainText("null"));
   }
 
   @Test
   public void errorDescriptionForDoesNotContainTextMatcher() {
     XLS xls = new XLS(new File("src/test/resources/small.xls"));
     try {
-      assertThat(xls, doesNotContainsText("Выписка"));
+      assertThat(xls, doesNotContainText("Выписка"));
       fail("expected AssertionError");
     }
     catch (AssertionError expected) {

--- a/src/test/java/com/codeborne/xlstest/matchers/ContainsTextTest.java
+++ b/src/test/java/com/codeborne/xlstest/matchers/ContainsTextTest.java
@@ -7,8 +7,9 @@ import java.io.File;
 import java.io.IOException;
 
 import static com.codeborne.xlstest.XLS.containsText;
-import static org.hamcrest.Matchers.is;
+import static com.codeborne.xlstest.XLS.doesNotContainsText;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.fail;
 
 public class ContainsTextTest {
@@ -51,7 +52,28 @@ public class ContainsTextTest {
   }
 
   @Test
-  public void errorDescription() {
+  public void canAssertXlsDoesNotContainText() throws IOException {
+    XLS xls = new XLS(getClass().getClassLoader().getResource("statement.xls"));
+    assertThat(xls, doesNotContainsText("null"));
+  }
+
+  @Test
+  public void errorDescriptionForDoesNotContainTextMatcher() {
+    XLS xls = new XLS(new File("src/test/resources/small.xls"));
+    try {
+      assertThat(xls, doesNotContainsText("Выписка"));
+      fail("expected AssertionError");
+    }
+    catch (AssertionError expected) {
+      assertThat(expected.getMessage(), is(
+        "\nExpected: a XLS not containing text \"Выписка\"" +
+          "\n     but: was \"" + System.getProperty("user.dir") + "/src/test/resources/small.xls\"" +
+          "\nВыписка\t\t\nСчёт\t40820810590480000591\t\n"));
+    }
+  }
+
+  @Test
+  public void errorDescriptionForContainsTextMatcher() {
     XLS xls = new XLS(new File("src/test/resources/small.xls"));
     try {
       assertThat(xls, containsText("wrong text"));

--- a/src/test/java/com/codeborne/xlstest/matchers/ContainsTextTest.java
+++ b/src/test/java/com/codeborne/xlstest/matchers/ContainsTextTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Objects;
 
 import static com.codeborne.xlstest.XLS.containsText;
 import static com.codeborne.xlstest.XLS.doesNotContainsText;
@@ -15,7 +16,7 @@ import static org.junit.Assert.fail;
 public class ContainsTextTest {
   @Test
   public void canAssertThatXlsContainsText() throws IOException {
-    XLS XLS = new XLS(getClass().getClassLoader().getResource("statement.xls"));
+    XLS XLS = new XLS(Objects.requireNonNull(getClass().getClassLoader().getResource("statement.xls")));
     assertThat(XLS, containsText("Выписка"));
     assertThat(XLS, containsText("Solntsev Andrei"));
     assertThat(XLS, containsText("25.06.2015 23:09:32"));
@@ -53,7 +54,7 @@ public class ContainsTextTest {
 
   @Test
   public void canAssertXlsDoesNotContainText() throws IOException {
-    XLS xls = new XLS(getClass().getClassLoader().getResource("statement.xls"));
+    XLS xls = new XLS(Objects.requireNonNull(getClass().getClassLoader().getResource("statement.xls")));
     assertThat(xls, doesNotContainsText("null"));
   }
 


### PR DESCRIPTION
The `doesNotContainText` matcher is useful to assert that an XLS doesn't
contain an invalid text, like `null` or `N/A` or an invalid date like `01
01 0001` and so on.